### PR TITLE
Allow Support for Raspberry Pi 2 Model B

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 CC=g++
-CCFLAGS=-Wall -Ofast -mfpu=vfp -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -march=armv6zk -mtune=arm1176jzf-s
+PIREV := $(shell cat /proc/cpuinfo | grep Revision | cut -f 2 -d ":" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$$//')
+CCFLAGS=-Wall -Ofast -mfpu=vfp -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -mtune=arm1176jzf-s
+ifeq (${PIREV},a01041)
+	CCFLAGS += -march=armv7-a -D__PI_2
+else
+	CCFLAGS += -march=armv6zk
+endif
 
 # define all programs
 PROGRAMS = MyGateway MySensor MyMessage PiEEPROM
@@ -34,5 +40,5 @@ ${GATEWAY_SERIAL}: ${OBJS} ${GATEWAY_SERIAL_OBJS}
 	${CC} -o $@ ${OBJS} ${GATEWAY_SERIAL_OBJS} ${CCFLAGS} ${CINCLUDE} -lrf24-bcm -lutil
 
 clean:
-	rm -rf $(PROGRAMS) $(GATEWAY) $(GATEWAY_SERIAL) $(BUILDDIR)/${OBJS}
+	rm -rf $(PROGRAMS) $(GATEWAY) $(GATEWAY_SERIAL) ${OBJS} $(GATEWAY_OBJS) $(GATEWAY_SERIAL_OBJS)
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,20 @@
 CC=g++
+# get PI Revision from cpuinfo
 PIREV := $(shell cat /proc/cpuinfo | grep Revision | cut -f 2 -d ":" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$$//')
 CCFLAGS=-Wall -Ofast -mfpu=vfp -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -mtune=arm1176jzf-s
-ifeq (${PIREV},a01041)
-	CCFLAGS += -march=armv7-a -D__PI_2
+
+ifeq (${PIREV},$(filter ${PIREV},a01041 a21041))
+	# a01041 and a21041 are PI 2 Model B and armv7
+	CCFLAGS += -march=armv7-a 
 else
+	# anything else is armv6
 	CCFLAGS += -march=armv6zk
 endif
+
+ifeq (${PIREV},$(filter ${PIREV},a01041 a21041 0010))
+	# a01041 and a21041 are PI 2 Model B with BPLUS Layout and 0010 is Pi Model B+ with BPLUS Layout
+	CCFLAGS += -D__PI_BPLUS
+endif 
 
 # define all programs
 PROGRAMS = MyGateway MySensor MyMessage PiEEPROM

--- a/MyConfig.h
+++ b/MyConfig.h
@@ -30,7 +30,7 @@
 /***
  * Enable/Disable debug logging
  */
-// #define DEBUG
+#define DEBUG
 
 
 #ifdef __Raspberry_Pi 

--- a/PiGatewaySerial.cpp
+++ b/PiGatewaySerial.cpp
@@ -99,7 +99,11 @@ int main(int argc, char **argv)
 	signal(SIGINT, handle_sigint);
 
 	/* create MySensors Gateway object */
+#ifdef PI_2
+	gw = new MyGateway(RPI_BPLUS_GPIO_J8_15, RPI_BPLUS_GPIO_J8_24, BCM2835_SPI_SPEED_8MHZ, 60);
+#else
 	gw = new MyGateway(RPI_V2_GPIO_P1_22, BCM2835_SPI_CS0, BCM2835_SPI_SPEED_8MHZ, 60);
+#endif	
 	if (gw == NULL)
 	{
 		printf("Could not create MyGateway! (%d) %s\n", errno, strerror(errno));

--- a/PiGatewaySerial.cpp
+++ b/PiGatewaySerial.cpp
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
 	signal(SIGINT, handle_sigint);
 
 	/* create MySensors Gateway object */
-#ifdef PI_2
+#ifdef __PI_BPLUS
 	gw = new MyGateway(RPI_BPLUS_GPIO_J8_15, RPI_BPLUS_GPIO_J8_24, BCM2835_SPI_SPEED_8MHZ, 60);
 #else
 	gw = new MyGateway(RPI_V2_GPIO_P1_22, BCM2835_SPI_CS0, BCM2835_SPI_SPEED_8MHZ, 60);

--- a/librf24-bcm/Makefile
+++ b/librf24-bcm/Makefile
@@ -13,6 +13,9 @@
 #
 PREFIX=/usr/local
 
+IOBASE := $(shell cat /proc/iomem | grep bcm2708_vcio | cut -f 1 -d "-")
+PIREV := $(shell cat /proc/cpuinfo | grep Revision | cut -f 2 -d ":" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$$//')
+
 # Library parameters
 # where to put the lib
 LIBDIR=$(PREFIX)/lib
@@ -25,7 +28,13 @@ LIBNAME=$(LIB).so.1.0
 HEADER_DIR=${PREFIX}/include/RF24
 
 # The recommended compiler flags for the Raspberry Pi
-CCFLAGS=-Ofast -mfpu=vfp -mfloat-abi=hard -march=armv6zk -mtune=arm1176jzf-s
+CCFLAGS=-Ofast -mfpu=vfp -mfloat-abi=hard -mtune=arm1176jzf-s
+ifeq (${PIREV},a01041)
+	CCFLAGS += -march=armv7-a
+else
+	CCFLAGS += -march=armv6zk
+endif
+CCFLAGS += -D BCM2835_PERI_BASE=0x${IOBASE}
 
 # make all
 # reinstall the library after each recompilation

--- a/librf24-bcm/Makefile
+++ b/librf24-bcm/Makefile
@@ -29,7 +29,7 @@ HEADER_DIR=${PREFIX}/include/RF24
 
 # The recommended compiler flags for the Raspberry Pi
 CCFLAGS=-Ofast -mfpu=vfp -mfloat-abi=hard -mtune=arm1176jzf-s
-ifeq (${PIREV},a01041)
+ifeq (${PIREV},$(filter ${PIREV},a01041 a21041))
 	CCFLAGS += -march=armv7-a
 else
 	CCFLAGS += -march=armv6zk

--- a/librf24-bcm/bcm2835.h
+++ b/librf24-bcm/bcm2835.h
@@ -342,7 +342,9 @@
 
 // Physical addresses for various peripheral register sets
 /// Base Physical Address of the BCM 2835 peripheral registers
+#ifndef BCM2835_PERI_BASE
 #define BCM2835_PERI_BASE               0x20000000
+#endif
 /// Base Physical Address of the System Timer registers
 #define BCM2835_ST_BASE			(BCM2835_PERI_BASE + 0x3000)
 /// Base Physical Address of the Pads registers


### PR DESCRIPTION
I agree to the CLA.

- Changed the librf24-bcm Makefile to automatically detect the setting for BCM2835_PERI_BASE this is different for Raspberry Pi 2 Model B
- Changed the librf24-bcm Makefile to automatically set the build architecture
- Changed the Makefile to detect the Pi Hardware Revision and set the CCFLAGS accordingly:
  - Raspberry Pi 2 Model B will be build with architecture armv7 and BPLUS GPIO Pin Layout
  - Raspberry Pi Model B+ will be build with architecture armv6 and  BPLUS GPIO Pin Layout
  - everything else will be build with armv6 and V2 GPIO Pin Layout
- Changed the Makefile definition for clean to include all .o files

This was successfully tested on a PI 2 and Pi Model B Revision 2.0. 