### PR TITLE
PiGatewaySerial as propper daemon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Set the name of predictable tty
 TTY_NAME := /dev/ttyMySensorsGateway
 # Set the group name for the raw tty
-TTY_GROUPNAME := tty
+TTY_GROUPNAME := dialout
 ##########################################################################
 # Please do not change anything below this line                          #
 ##########################################################################

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
+##########################################################################
+# Configurable options                                                   #
+##########################################################################
+# Set the name of predictable tty
+TTY_NAME := /dev/ttyMySensorsGateway
+# Set the group name for the raw tty
+TTY_GROUPNAME := tty
+##########################################################################
+# Please do not change anything below this line                          #
+##########################################################################
 CC=g++
 # get PI Revision from cpuinfo
 PIREV := $(shell cat /proc/cpuinfo | grep Revision | cut -f 2 -d ":" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$$//')
-CCFLAGS=-Wall -Ofast -mfpu=vfp -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -mtune=arm1176jzf-s
+CCFLAGS=-Wall -Ofast -mfpu=vfp -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -mtune=arm1176jzf-s -D_TTY_NAME=\"${TTY_NAME}\" -D_TTY_GROUPNAME=\"${TTY_GROUPNAME}\"
 
 ifeq (${PIREV},$(filter ${PIREV},a01041 a21041))
 	# a01041 and a21041 are PI 2 Model B and armv7

--- a/MySensor.cpp
+++ b/MySensor.cpp
@@ -279,7 +279,7 @@ boolean MySensor::process() {
 
 	if (!available || pipe>6)
 		return false;
-
+	memset(&msg,0,sizeof(MyMessage));
 	uint8_t len = RF24::getDynamicPayloadSize();
 	RF24::read(&msg, len);
 	RF24::writeAckPayload(pipe,&pipe, 1 );

--- a/MySensor.h
+++ b/MySensor.h
@@ -44,10 +44,12 @@
 	#include <string>
 	#include <getopt.h>
 	#include <iostream>
+	#include <syslog.h>
 #endif
 
 #ifdef DEBUG
-	#define debug(x,...) debugPrint(x, ##__VA_ARGS__)
+	extern void log(int priority, const char *format, ...);
+	#define debug(x,...) log(LOG_DEBUG, x, ##__VA_ARGS__)
 #else
 	#define debug(x,...)
 #endif

--- a/PiGateway.cpp
+++ b/PiGateway.cpp
@@ -15,9 +15,29 @@
 
 MyGateway *gw;
 
+int daemonizeFlag = 0;
+
+void openSyslog()
+{
+    setlogmask(LOG_UPTO (LOG_INFO));
+    openlog(NULL, 0, LOG_USER);
+}
+
+void closeSyslog()
+{
+    closelog();
+}
+
 void log(int priority, const char *format, ...)
 {
-	// dummy to make it compile correctly, needs to be changed later
+	va_list argptr;
+    va_start(argptr, format);
+    if (daemonizeFlag == 1) {
+		vsyslog(priority, format, argptr);
+	} else {
+		vprintf(format, argptr);
+	}
+	va_end(argptr);
 }
 
 void msgCallback(char *msg){
@@ -27,8 +47,8 @@ void msgCallback(char *msg){
 
 void setup(void)
 {
-	printf("Starting Gateway...\n");
-	gw = new MyGateway(RPI_V2_GPIO_P1_22, RPI_V2_GPIO_P1_24, BCM2835_SPI_SPEED_8MHZ, 30000);
+	printf("Starting Gateway...\n"); 
+	gw = new MyGateway(RPI_V2_GPIO_P1_22, RPI_V2_GPIO_P1_24, BCM2835_SPI_SPEED_8MHZ, 60);
 	
 	if (gw == NULL)
     {
@@ -44,9 +64,10 @@ void loop(void)
 
 int main(int argc, char** argv) 
 {
+	openSyslog();
 	setup();
 	while(1)
 		loop();
-	
+	closeSyslog();
 	return 0;
 }

--- a/PiGateway.cpp
+++ b/PiGateway.cpp
@@ -15,6 +15,11 @@
 
 MyGateway *gw;
 
+void log(int priority, const char *format, ...)
+{
+	// dummy to make it compile correctly, needs to be changed later
+}
+
 void msgCallback(char *msg){
 	printf("[CALLBACK]%s", msg);
 

--- a/PiGatewaySerial.cpp
+++ b/PiGatewaySerial.cpp
@@ -93,7 +93,7 @@ void handle_sigusr1(int sig)
 {
 	log(LOG_INFO,"Received SIGUSR1\n");
 	int curLogLevel = setlogmask(0);
-	if (curLogLevel != LOG_DEBUG) setlogmask(LOG_UPTO (LOG_DEBUG));
+	if (curLogLevel != LOG_UPTO(LOG_DEBUG)) setlogmask(LOG_UPTO (LOG_DEBUG));
 	else setlogmask(LOG_UPTO (LOG_INFO));
 }
 

--- a/PiGatewaySerial.cpp
+++ b/PiGatewaySerial.cpp
@@ -99,6 +99,7 @@ int main(int argc, char **argv)
 
 	/* register the signal handler */
 	signal(SIGINT, handle_sigint);
+	signal(SIGTERM, handle_sigint);
 
 	/* create MySensors Gateway object */
 #ifdef __PI_BPLUS

--- a/README
+++ b/README
@@ -1,0 +1,54 @@
+Wiring the NRF24
+
+Checking your Hardware Version
+
+On the shell execute 'cat /proc/cpuinfo' at the bottom of the output you will find the
+field 'Revision'. Revision values of a01041, a21041 or 0010 inidicate Hardware Version
+B+ anything else V2.
+
+Pi Hardware Version V2
+
+GND	  25
+VCC	  17
+CE	  22
+CSN   24
+SCK   23
+MOSI  19
+MISO  21
+IRQ	  --
+
+Pi Hardware Version B+
+
+GND	  25
+VCC	  17
+CE	  15
+CSN   24
+SCK   23
+MOSI  19
+MISO  21
+IRQ	  --
+
+Building Serial Gateway
+
+The standard configuration will build the Serial Gateway with a tty name of
+'/dev/ttyMySensorsGateway' and PTS group ownership of 'tty' the PTS will be group read 
+and write. The default install location will be /usr/local/sbin. If you want to change
+that edit the variables in the head of the Makefile.
+
+First build the librf24-bcm library
+
+- Change to librf24-bcm
+- make all
+- sudo make install
+
+Build the Gateway
+
+- change back to Raspberry Dir
+- make all
+- sudo make install
+- (if you want to start daemon at boot) sudo make enable-gwserial
+
+Uninstalling 
+
+- change to Raspberry Dir
+- sudo make uninstall

--- a/initscripts/30-PiGateway.conf
+++ b/initscripts/30-PiGateway.conf
@@ -1,0 +1,2 @@
+if $programname == 'PiGateway' then /var/log/PiGateway.log
+& ~

--- a/initscripts/30-PiGatewaySerial.conf
+++ b/initscripts/30-PiGatewaySerial.conf
@@ -1,0 +1,2 @@
+if $programname == 'PiGatewaySerial' then /var/log/PiGatewaySerial.log
+& ~

--- a/initscripts/PiGateway
+++ b/initscripts/PiGateway
@@ -1,0 +1,159 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          PiGateway
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: MySensors Gateway
+# Description:       This file should be used to construct scripts to be
+#                    placed in /etc/init.d.
+### END INIT INFO
+
+# Author: Foo Bar <foobar@baz.org>
+#
+# Please remove the "Author" lines above and replace them
+# with your own name if you copy and modify this script.
+
+# Do NOT "set -e"
+
+# PATH should only include /usr/* if it runs after the mountnfs.sh script
+PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/sbin:/usr/local/bin
+DESC="MySensors Gateway"
+NAME=PiGateway
+DAEMON=/usr/local/sbin/$NAME
+DAEMON_ARGS="-d"
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME 
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.2-14) to ensure that this file is present
+# and status_of_proc is working.
+. /lib/lsb/init-functions
+
+#
+# Function that starts the daemon/service
+#
+do_start()
+{
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+	start-stop-daemon --start --quiet --exec $DAEMON --test > /dev/null \
+		|| return 1
+	start-stop-daemon --start --quiet --exec $DAEMON -- \
+		$DAEMON_ARGS \
+		|| return 2
+	# Add code here, if necessary, that waits for the process to be ready
+	# to handle requests from services started subsequently which depend
+	# on this one.  As a last resort, sleep for some time.
+}
+
+#
+# Function that stops the daemon/service
+#
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --name $NAME
+	RETVAL="$?"
+	[ "$RETVAL" = 2 ] && return 2
+	# Wait for children to finish too if this is a daemon that forks
+	# and if the daemon is only ever run from this initscript.
+	# If the above conditions are not satisfied then add some other code
+	# that waits for the process to drop all resources that could be
+	# needed by services started subsequently.  A last resort is to
+	# sleep for some time.
+	start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
+	[ "$?" = 2 ] && return 2
+	# Many daemons don't delete their pidfiles when they exit.
+	rm -f $PIDFILE
+	return "$RETVAL"
+}
+
+#
+# Function that sends a SIGHUP to the daemon/service
+#
+do_reload() {
+	#
+	# If the daemon can reload its configuration without
+	# restarting (for example, when it is sent a SIGHUP),
+	# then implement that here.
+	#
+	start-stop-daemon --stop --signal 1 --quiet --name $NAME
+	return 0
+}
+
+case "$1" in
+  start)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+	do_start
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  stop)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+	do_stop
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  status)
+	status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+	;;
+  #reload|force-reload)
+	#
+	# If do_reload() is not implemented then leave this commented out
+	# and leave 'force-reload' as an alias for 'restart'.
+	#
+	#log_daemon_msg "Reloading $DESC" "$NAME"
+	#do_reload
+	#log_end_msg $?
+	#;;
+  restart|force-reload)
+	#
+	# If the "reload" option is implemented then remove the
+	# 'force-reload' alias
+	#
+	log_daemon_msg "Restarting $DESC" "$NAME"
+	do_stop
+	case "$?" in
+	  0|1)
+		do_start
+		case "$?" in
+			0) log_end_msg 0 ;;
+			1) log_end_msg 1 ;; # Old process is still running
+			*) log_end_msg 1 ;; # Failed to start
+		esac
+		;;
+	  *)
+		# Failed to stop
+		log_end_msg 1
+		;;
+	esac
+	;;
+  *)
+	#echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	exit 3
+	;;
+esac
+
+:

--- a/initscripts/PiGatewaySerial
+++ b/initscripts/PiGatewaySerial
@@ -1,0 +1,159 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          PiGatewaySerial
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: MySensors Serial Gateway
+# Description:       This file should be used to construct scripts to be
+#                    placed in /etc/init.d.
+### END INIT INFO
+
+# Author: Foo Bar <foobar@baz.org>
+#
+# Please remove the "Author" lines above and replace them
+# with your own name if you copy and modify this script.
+
+# Do NOT "set -e"
+
+# PATH should only include /usr/* if it runs after the mountnfs.sh script
+PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/sbin:/usr/local/bin
+DESC="MySensors Serial Gateway"
+NAME=PiGatewaySerial
+DAEMON=/usr/local/sbin/$NAME
+DAEMON_ARGS="-d"
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME 
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.2-14) to ensure that this file is present
+# and status_of_proc is working.
+. /lib/lsb/init-functions
+
+#
+# Function that starts the daemon/service
+#
+do_start()
+{
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+	start-stop-daemon --start --quiet --exec $DAEMON --test > /dev/null \
+		|| return 1
+	start-stop-daemon --start --quiet --exec $DAEMON -- \
+		$DAEMON_ARGS \
+		|| return 2
+	# Add code here, if necessary, that waits for the process to be ready
+	# to handle requests from services started subsequently which depend
+	# on this one.  As a last resort, sleep for some time.
+}
+
+#
+# Function that stops the daemon/service
+#
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --name $NAME
+	RETVAL="$?"
+	[ "$RETVAL" = 2 ] && return 2
+	# Wait for children to finish too if this is a daemon that forks
+	# and if the daemon is only ever run from this initscript.
+	# If the above conditions are not satisfied then add some other code
+	# that waits for the process to drop all resources that could be
+	# needed by services started subsequently.  A last resort is to
+	# sleep for some time.
+	start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
+	[ "$?" = 2 ] && return 2
+	# Many daemons don't delete their pidfiles when they exit.
+	rm -f $PIDFILE
+	return "$RETVAL"
+}
+
+#
+# Function that sends a SIGHUP to the daemon/service
+#
+do_reload() {
+	#
+	# If the daemon can reload its configuration without
+	# restarting (for example, when it is sent a SIGHUP),
+	# then implement that here.
+	#
+	start-stop-daemon --stop --signal 1 --quiet --name $NAME
+	return 0
+}
+
+case "$1" in
+  start)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+	do_start
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  stop)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+	do_stop
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  status)
+	status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+	;;
+  #reload|force-reload)
+	#
+	# If do_reload() is not implemented then leave this commented out
+	# and leave 'force-reload' as an alias for 'restart'.
+	#
+	#log_daemon_msg "Reloading $DESC" "$NAME"
+	#do_reload
+	#log_end_msg $?
+	#;;
+  restart|force-reload)
+	#
+	# If the "reload" option is implemented then remove the
+	# 'force-reload' alias
+	#
+	log_daemon_msg "Restarting $DESC" "$NAME"
+	do_stop
+	case "$?" in
+	  0|1)
+		do_start
+		case "$?" in
+			0) log_end_msg 0 ;;
+			1) log_end_msg 1 ;; # Old process is still running
+			*) log_end_msg 1 ;; # Failed to start
+		esac
+		;;
+	  *)
+		# Failed to stop
+		log_end_msg 1
+		;;
+	esac
+	;;
+  *)
+	#echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	exit 3
+	;;
+esac
+
+:


### PR DESCRIPTION
I changed the PiGatewaySerial to work as a proper UNIX daemon with the following changes:

- the default PTY permissions now include group readability 
- the group ownership can now be changed to allow non root processes to access the PTY
- the daemon now ends on SIGTERM too
- added cmdline option -d which will make the PiGatewaySerial to detach from the tty
- Detached processes will log to syslog, instead of the tty (non detached processes will still log to the tty)
- Debug logging can be turned on and off on the fly by sending SIGUSR1 to the daemon process.
- modified the Makefile to include install/uninstall support and enable/disable of daemon automatic start
- BUGFIX: The union passed to read was only partially be written. If something longer (floats) was received the evaluation of unsigned int values was broken. Zeroed the memory before passing it to Read. Weirdly this is the same code as for the arduino, where I have not seen similar behavior.
- Added a README with the values which worked for me.