### PR TITLE
Fixed MySensor::millis() Implementation

### DIFF
--- a/MySensor.cpp
+++ b/MySensor.cpp
@@ -37,6 +37,9 @@ inline MyMessage& build (MyMessage &msg, uint8_t sender, uint8_t destination, ui
 
 #ifdef __Raspberry_Pi
 MySensor::MySensor(uint8_t _cepin, uint8_t _cspin, uint32_t spispeed ) : RF24(_cepin, _cspin, spispeed){
+	timeval curTime;
+	gettimeofday(&curTime, NULL);
+	millis_at_start = curTime.tv_sec;
 }
 #else
 MySensor::MySensor(uint8_t _cepin, uint8_t _cspin) : RF24(_cepin, _cspin) {
@@ -597,7 +600,7 @@ unsigned long MySensor::millis()
 {
     timeval curTime;
     gettimeofday(&curTime, NULL);
-    return curTime.tv_usec / 1000;
+    return ((curTime.tv_sec - millis_at_start) * 1000) + (curTime.tv_usec / 1000);
 }
 
 /**

--- a/MySensor.h
+++ b/MySensor.h
@@ -280,7 +280,8 @@ class MySensor : public RF24
 	boolean sendWrite(uint8_t dest, MyMessage &message, bool broadcast=false);
 
 #ifdef __Raspberry_Pi
-	long unsigned int millis();
+	unsigned long millis();
+	unsigned long millis_at_start;
 	char * itoa(int value, char *result, int base);
 	char * ltoa(long value, char *result, int base);
 	char * dtostrf(float f, int width, int decimals, char *result);

--- a/PiGatewaySerial.cpp
+++ b/PiGatewaySerial.cpp
@@ -197,9 +197,9 @@ int main(int argc, char **argv)
 	
 	/* create MySensors Gateway object */
 #ifdef __PI_BPLUS
-	gw = new MyGateway(RPI_BPLUS_GPIO_J8_15, RPI_BPLUS_GPIO_J8_24, BCM2835_SPI_SPEED_8MHZ, 60);
+	gw = new MyGateway(RPI_BPLUS_GPIO_J8_15, RPI_BPLUS_GPIO_J8_24, BCM2835_SPI_SPEED_8MHZ, 1);
 #else
-	gw = new MyGateway(RPI_V2_GPIO_P1_22, BCM2835_SPI_CS0, BCM2835_SPI_SPEED_8MHZ, 60);
+	gw = new MyGateway(RPI_V2_GPIO_P1_22, BCM2835_SPI_CS0, BCM2835_SPI_SPEED_8MHZ, 1);
 #endif	
 	if (gw == NULL)
 	{


### PR DESCRIPTION
The implementation of unsigned long MySensor::millis() has a serious problem, because it is only using the microsecond remainder of the current second to return millis. This caused the inclusion mode timeout to be something of a lottery. 

I changed the implementation to return the milliseconds since program start.