### PR TITLE
fix min function compilation error

### DIFF
--- a/MySensor.cpp
+++ b/MySensor.cpp
@@ -12,6 +12,8 @@
 
 #include "MySensor.h"
 
+using namespace std;
+
 #ifdef __Raspberry_Pi
 	#include <PiEEPROM.h>
 	#include "RF24.h"


### PR DESCRIPTION
error: ‘min’ was not declared in this scope