### PR TITLE
Fixes issue where process is terminated ungracefully because of thrown exceptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,18 +15,22 @@ TTY_GROUPNAME := tty
 CC=g++
 # get PI Revision from cpuinfo
 PIREV := $(shell cat /proc/cpuinfo | grep Revision | cut -f 2 -d ":" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$$//')
-CCFLAGS=-Wall -Ofast -mfpu=vfp -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -mtune=arm1176jzf-s -D_TTY_NAME=\"${TTY_NAME}\" -D_TTY_GROUPNAME=\"${TTY_GROUPNAME}\"
+CCFLAGS=-Wall -Ofast -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -D_TTY_NAME=\"${TTY_NAME}\" -D_TTY_GROUPNAME=\"${TTY_GROUPNAME}\"
 
-ifeq (${PIREV},$(filter ${PIREV},a01041 a21041))
-	# a01041 and a21041 are PI 2 Model B and armv7
-	CCFLAGS += -march=armv7-a
+ifeq (${PIREV}, $(filter ${PIREV}, a02082))
+	# a02082 is PI 3 Model B (ARM Cortex A53)
+	CCFLAGS += -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8
+else (${PIREV}, $(filter ${PIREV}, a01041 a21041))
+	# a01041 and a21041 are PI 2 Model B (Arm Cortex A7)
+	CCFLAGS += -march=armv7-a -mtune=cortex-a7 -mfpu=neon-vfpv4
 else
 	# anything else is armv6
-	CCFLAGS += -march=armv6zk
+	CCFLAGS += -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp
 endif
 
-ifeq (${PIREV},$(filter ${PIREV},a01041 a21041 0010))
+ifeq (${PIREV}, $(filter ${PIREV}, a01041 a21041 0010 a02082))
 	# a01041 and a21041 are PI 2 Model B with BPLUS Layout and 0010 is Pi Model B+ with BPLUS Layout
+	# a02082 is PI 3 Model B (ARM Cortex A53)
 	CCFLAGS += -D__PI_BPLUS
 endif
 
@@ -103,4 +107,3 @@ uninstall: remove-gw remove-gwserial
 	-@service PiGateway stop
 	@echo "removing files"
 	rm ${BINDIR}/PiGatewaySerial ${BINDIR}/PiGateway /etc/init.d/PiGatewaySerial /etc/init.d/PiGateway /etc/rsyslog.d/30-PiGatewaySerial.conf /etc/rsyslog.d/30-PiGateway.conf
-	

--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,14 @@ else (${PIREV}, $(filter ${PIREV}, a01041 a21041))
   # a01041 and a21041 are PI 2 Model B (Arm Cortex A7)
   CCFLAGS += -march=armv7-a -mtune=cortex-a7 -mfpu=neon-vfpv4
 else
-	# anything else is armv6
-	CCFLAGS += -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp
+  # anything else is armv6
+  CCFLAGS += -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp
 endif
 
 ifeq (${PIREV}, $(filter ${PIREV}, a01041 a21041 0010 a02082))
-	# a01041 and a21041 are PI 2 Model B with BPLUS Layout and 0010 is Pi Model B+ with BPLUS Layout
-	# a02082 is PI 3 Model B (ARM Cortex A53)
-	CCFLAGS += -D__PI_BPLUS
+  # a01041 and a21041 are PI 2 Model B with BPLUS Layout and 0010 is Pi Model B+ with BPLUS Layout
+  # a02082 is PI 3 Model B (ARM Cortex A53)
+  CCFLAGS += -D__PI_BPLUS
 endif
 
 # define all programs
@@ -58,52 +58,52 @@ CINCLUDE=-I. -I${RF24H}
 all: ${GATEWAY} ${GATEWAY_SERIAL}
 
 %.o: %.cpp %.h ${DEPS}
-	${CC} -c -o $@ $< ${CCFLAGS} ${CINCLUDE}
+  ${CC} -c -o $@ $< ${CCFLAGS} ${CINCLUDE}
 
 ${GATEWAY}: ${OBJS} ${GATEWAY_OBJS}
-	${CC} -o $@ ${OBJS} ${GATEWAY_OBJS} ${CCFLAGS} ${CINCLUDE} -lrf24-bcm
+  ${CC} -o $@ ${OBJS} ${GATEWAY_OBJS} ${CCFLAGS} ${CINCLUDE} -lrf24-bcm
 
 ${GATEWAY_SERIAL}: ${OBJS} ${GATEWAY_SERIAL_OBJS}
-	${CC} -o $@ ${OBJS} ${GATEWAY_SERIAL_OBJS} ${CCFLAGS} ${CINCLUDE} -lrf24-bcm -lutil
+  ${CC} -o $@ ${OBJS} ${GATEWAY_SERIAL_OBJS} ${CCFLAGS} ${CINCLUDE} -lrf24-bcm -lutil
 
 clean:
-	rm -rf $(PROGRAMS) $(GATEWAY) $(GATEWAY_SERIAL) ${OBJS} $(GATEWAY_OBJS) $(GATEWAY_SERIAL_OBJS)
+  rm -rf $(PROGRAMS) $(GATEWAY) $(GATEWAY_SERIAL) ${OBJS} $(GATEWAY_OBJS) $(GATEWAY_SERIAL_OBJS)
 
 install: all install-gatewayserial install-gateway install-initscripts
 
 install-gatewayserial:
-	@echo "Installing ${GATEWAY_SERIAL} to ${BINDIR}"
-	@install -m 0755 ${GATEWAY_SERIAL} ${BINDIR}
+  @echo "Installing ${GATEWAY_SERIAL} to ${BINDIR}"
+  @install -m 0755 ${GATEWAY_SERIAL} ${BINDIR}
 
 install-gateway:
-	@echo "Installing ${GATEWAY} to ${BINDIR}"
-	@install -m 0755 ${GATEWAY} ${BINDIR}
+  @echo "Installing ${GATEWAY} to ${BINDIR}"
+  @install -m 0755 ${GATEWAY} ${BINDIR}
 
 install-initscripts:
-	@echo "Installing initscripts to /etc/init.d"
-	@install -m 0755 initscripts/PiGatewaySerial /etc/init.d
-	@install -m 0755 initscripts/PiGateway /etc/init.d
-	@echo "Installing syslog config to /etc/rsyslog.d"
-	@install -m 0755 initscripts/30-PiGatewaySerial.conf /etc/rsyslog.d
-	@install -m 0755 initscripts/30-PiGateway.conf  /etc/rsyslog.d
-	@service rsyslog restart
+  @echo "Installing initscripts to /etc/init.d"
+  @install -m 0755 initscripts/PiGatewaySerial /etc/init.d
+  @install -m 0755 initscripts/PiGateway /etc/init.d
+  @echo "Installing syslog config to /etc/rsyslog.d"
+  @install -m 0755 initscripts/30-PiGatewaySerial.conf /etc/rsyslog.d
+  @install -m 0755 initscripts/30-PiGateway.conf  /etc/rsyslog.d
+  @service rsyslog restart
 
 enable-gw: install
-	@update-rc.d PiGateway defaults
+  @update-rc.d PiGateway defaults
 
 enable-gwserial: install
-	@update-rc.d PiGatewaySerial defaults
+  @update-rc.d PiGatewaySerial defaults
 
 remove-gw:
-	@update-rc.d -f PiGateway remove
+  @update-rc.d -f PiGateway remove
 
 remove-gwserial:
-	@update-rc.d -f PiGatewaySerial remove
+  @update-rc.d -f PiGatewaySerial remove
 
 uninstall: remove-gw remove-gwserial
-	@echo "Stopping daemon PiGatewaySerial (ignore errors)"
-	-@service PiGatewaySerial stop
-	@echo "Stopping daemon PiGateway (ignore errors)"
-	-@service PiGateway stop
-	@echo "removing files"
-	rm ${BINDIR}/PiGatewaySerial ${BINDIR}/PiGateway /etc/init.d/PiGatewaySerial /etc/init.d/PiGateway /etc/rsyslog.d/30-PiGatewaySerial.conf /etc/rsyslog.d/30-PiGateway.conf
+  @echo "Stopping daemon PiGatewaySerial (ignore errors)"
+  -@service PiGatewaySerial stop
+  @echo "Stopping daemon PiGateway (ignore errors)"
+  -@service PiGateway stop
+  @echo "removing files"
+  rm ${BINDIR}/PiGatewaySerial ${BINDIR}/PiGateway /etc/init.d/PiGatewaySerial /etc/init.d/PiGateway /etc/rsyslog.d/30-PiGatewaySerial.conf /etc/rsyslog.d/30-PiGateway.conf

--- a/Makefile
+++ b/Makefile
@@ -15,24 +15,20 @@ TTY_GROUPNAME := tty
 CC=g++
 # get PI Revision from cpuinfo
 PIREV := $(shell cat /proc/cpuinfo | grep Revision | cut -f 2 -d ":" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$$//')
-CCFLAGS=-Wall -Ofast -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -D_TTY_NAME=\"${TTY_NAME}\" -D_TTY_GROUPNAME=\"${TTY_GROUPNAME}\"
+CCFLAGS=-Wall -Ofast -mfpu=vfp -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -mtune=arm1176jzf-s -D_TTY_NAME=\"${TTY_NAME}\" -D_TTY_GROUPNAME=\"${TTY_GROUPNAME}\"
 
-ifeq (${PIREV}, $(filter ${PIREV}, a02082))
-  # a02082 is PI 3 Model B (ARM Cortex A53)
-  CCFLAGS += -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8
-else (${PIREV}, $(filter ${PIREV}, a01041 a21041))
-  # a01041 and a21041 are PI 2 Model B (Arm Cortex A7)
-  CCFLAGS += -march=armv7-a -mtune=cortex-a7 -mfpu=neon-vfpv4
+ifeq (${PIREV},$(filter ${PIREV},a01041 a21041))
+	# a01041 and a21041 are PI 2 Model B and armv7
+	CCFLAGS += -march=armv7-a 
 else
 	# anything else is armv6
-	CCFLAGS += -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp
+	CCFLAGS += -march=armv6zk
 endif
 
-ifeq (${PIREV}, $(filter ${PIREV}, a01041 a21041 0010 a02082))
+ifeq (${PIREV},$(filter ${PIREV},a01041 a21041 0010))
 	# a01041 and a21041 are PI 2 Model B with BPLUS Layout and 0010 is Pi Model B+ with BPLUS Layout
-	# a02082 is PI 3 Model B (ARM Cortex A53)
 	CCFLAGS += -D__PI_BPLUS
-endif
+endif 
 
 # define all programs
 PROGRAMS = MyGateway MySensor MyMessage PiEEPROM
@@ -71,14 +67,14 @@ clean:
 
 install: all install-gatewayserial install-gateway install-initscripts
 
-install-gatewayserial:
+install-gatewayserial: 
 	@echo "Installing ${GATEWAY_SERIAL} to ${BINDIR}"
 	@install -m 0755 ${GATEWAY_SERIAL} ${BINDIR}
 
-install-gateway:
+install-gateway: 
 	@echo "Installing ${GATEWAY} to ${BINDIR}"
 	@install -m 0755 ${GATEWAY} ${BINDIR}
-
+	
 install-initscripts:
 	@echo "Installing initscripts to /etc/init.d"
 	@install -m 0755 initscripts/PiGatewaySerial /etc/init.d
@@ -90,16 +86,16 @@ install-initscripts:
 
 enable-gw: install
 	@update-rc.d PiGateway defaults
-
+	
 enable-gwserial: install
 	@update-rc.d PiGatewaySerial defaults
-
+	
 remove-gw:
 	@update-rc.d -f PiGateway remove
-
+	
 remove-gwserial:
 	@update-rc.d -f PiGatewaySerial remove
-
+	
 uninstall: remove-gw remove-gwserial
 	@echo "Stopping daemon PiGatewaySerial (ignore errors)"
 	-@service PiGatewaySerial stop
@@ -107,3 +103,4 @@ uninstall: remove-gw remove-gwserial
 	-@service PiGateway stop
 	@echo "removing files"
 	rm ${BINDIR}/PiGatewaySerial ${BINDIR}/PiGateway /etc/init.d/PiGatewaySerial /etc/init.d/PiGateway /etc/rsyslog.d/30-PiGatewaySerial.conf /etc/rsyslog.d/30-PiGateway.conf
+	

--- a/Makefile
+++ b/Makefile
@@ -15,22 +15,18 @@ TTY_GROUPNAME := tty
 CC=g++
 # get PI Revision from cpuinfo
 PIREV := $(shell cat /proc/cpuinfo | grep Revision | cut -f 2 -d ":" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$$//')
-CCFLAGS=-Wall -Ofast -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -D_TTY_NAME=\"${TTY_NAME}\" -D_TTY_GROUPNAME=\"${TTY_GROUPNAME}\"
+CCFLAGS=-Wall -Ofast -mfpu=vfp -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -mtune=arm1176jzf-s -D_TTY_NAME=\"${TTY_NAME}\" -D_TTY_GROUPNAME=\"${TTY_GROUPNAME}\"
 
-ifeq (${PIREV}, $(filter ${PIREV}, a02082))
-	# a02082 is PI 3 Model B (ARM Cortex A53)
-	CCFLAGS += -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8
-else (${PIREV}, $(filter ${PIREV}, a01041 a21041))
-	# a01041 and a21041 are PI 2 Model B (Arm Cortex A7)
-	CCFLAGS += -march=armv7-a -mtune=cortex-a7 -mfpu=neon-vfpv4
+ifeq (${PIREV},$(filter ${PIREV},a01041 a21041))
+	# a01041 and a21041 are PI 2 Model B and armv7
+	CCFLAGS += -march=armv7-a
 else
 	# anything else is armv6
-	CCFLAGS += -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp
+	CCFLAGS += -march=armv6zk
 endif
 
-ifeq (${PIREV}, $(filter ${PIREV}, a01041 a21041 0010 a02082))
+ifeq (${PIREV},$(filter ${PIREV},a01041 a21041 0010))
 	# a01041 and a21041 are PI 2 Model B with BPLUS Layout and 0010 is Pi Model B+ with BPLUS Layout
-	# a02082 is PI 3 Model B (ARM Cortex A53)
 	CCFLAGS += -D__PI_BPLUS
 endif
 
@@ -107,3 +103,4 @@ uninstall: remove-gw remove-gwserial
 	-@service PiGateway stop
 	@echo "removing files"
 	rm ${BINDIR}/PiGatewaySerial ${BINDIR}/PiGateway /etc/init.d/PiGatewaySerial /etc/init.d/PiGateway /etc/rsyslog.d/30-PiGatewaySerial.conf /etc/rsyslog.d/30-PiGateway.conf
+	

--- a/Makefile
+++ b/Makefile
@@ -15,23 +15,19 @@ TTY_GROUPNAME := tty
 CC=g++
 # get PI Revision from cpuinfo
 PIREV := $(shell cat /proc/cpuinfo | grep Revision | cut -f 2 -d ":" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$$//')
-CCFLAGS=-Wall -Ofast -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -D_TTY_NAME=\"${TTY_NAME}\" -D_TTY_GROUPNAME=\"${TTY_GROUPNAME}\"
+CCFLAGS=-Wall -Ofast -mfpu=vfp -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -mtune=arm1176jzf-s -D_TTY_NAME=\"${TTY_NAME}\" -D_TTY_GROUPNAME=\"${TTY_GROUPNAME}\"
 
-ifeq (${PIREV}, $(filter ${PIREV}, a02082))
-  # a02082 is PI 3 Model B (ARM Cortex A53)
-  CCFLAGS += -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8
-else (${PIREV}, $(filter ${PIREV}, a01041 a21041))
-  # a01041 and a21041 are PI 2 Model B (Arm Cortex A7)
-  CCFLAGS += -march=armv7-a -mtune=cortex-a7 -mfpu=neon-vfpv4
+ifeq (${PIREV},$(filter ${PIREV},a01041 a21041))
+	# a01041 and a21041 are PI 2 Model B and armv7
+	CCFLAGS += -march=armv7-a
 else
-  # anything else is armv6
-  CCFLAGS += -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp
+	# anything else is armv6
+	CCFLAGS += -march=armv6zk
 endif
 
-ifeq (${PIREV}, $(filter ${PIREV}, a01041 a21041 0010 a02082))
-  # a01041 and a21041 are PI 2 Model B with BPLUS Layout and 0010 is Pi Model B+ with BPLUS Layout
-  # a02082 is PI 3 Model B (ARM Cortex A53)
-  CCFLAGS += -D__PI_BPLUS
+ifeq (${PIREV},$(filter ${PIREV},a01041 a21041 0010))
+	# a01041 and a21041 are PI 2 Model B with BPLUS Layout and 0010 is Pi Model B+ with BPLUS Layout
+	CCFLAGS += -D__PI_BPLUS
 endif
 
 # define all programs
@@ -58,52 +54,53 @@ CINCLUDE=-I. -I${RF24H}
 all: ${GATEWAY} ${GATEWAY_SERIAL}
 
 %.o: %.cpp %.h ${DEPS}
-  ${CC} -c -o $@ $< ${CCFLAGS} ${CINCLUDE}
+	${CC} -c -o $@ $< ${CCFLAGS} ${CINCLUDE}
 
 ${GATEWAY}: ${OBJS} ${GATEWAY_OBJS}
-  ${CC} -o $@ ${OBJS} ${GATEWAY_OBJS} ${CCFLAGS} ${CINCLUDE} -lrf24-bcm
+	${CC} -o $@ ${OBJS} ${GATEWAY_OBJS} ${CCFLAGS} ${CINCLUDE} -lrf24-bcm
 
 ${GATEWAY_SERIAL}: ${OBJS} ${GATEWAY_SERIAL_OBJS}
-  ${CC} -o $@ ${OBJS} ${GATEWAY_SERIAL_OBJS} ${CCFLAGS} ${CINCLUDE} -lrf24-bcm -lutil
+	${CC} -o $@ ${OBJS} ${GATEWAY_SERIAL_OBJS} ${CCFLAGS} ${CINCLUDE} -lrf24-bcm -lutil
 
 clean:
-  rm -rf $(PROGRAMS) $(GATEWAY) $(GATEWAY_SERIAL) ${OBJS} $(GATEWAY_OBJS) $(GATEWAY_SERIAL_OBJS)
+	rm -rf $(PROGRAMS) $(GATEWAY) $(GATEWAY_SERIAL) ${OBJS} $(GATEWAY_OBJS) $(GATEWAY_SERIAL_OBJS)
 
 install: all install-gatewayserial install-gateway install-initscripts
 
 install-gatewayserial:
-  @echo "Installing ${GATEWAY_SERIAL} to ${BINDIR}"
-  @install -m 0755 ${GATEWAY_SERIAL} ${BINDIR}
+	@echo "Installing ${GATEWAY_SERIAL} to ${BINDIR}"
+	@install -m 0755 ${GATEWAY_SERIAL} ${BINDIR}
 
 install-gateway:
-  @echo "Installing ${GATEWAY} to ${BINDIR}"
-  @install -m 0755 ${GATEWAY} ${BINDIR}
+	@echo "Installing ${GATEWAY} to ${BINDIR}"
+	@install -m 0755 ${GATEWAY} ${BINDIR}
 
 install-initscripts:
-  @echo "Installing initscripts to /etc/init.d"
-  @install -m 0755 initscripts/PiGatewaySerial /etc/init.d
-  @install -m 0755 initscripts/PiGateway /etc/init.d
-  @echo "Installing syslog config to /etc/rsyslog.d"
-  @install -m 0755 initscripts/30-PiGatewaySerial.conf /etc/rsyslog.d
-  @install -m 0755 initscripts/30-PiGateway.conf  /etc/rsyslog.d
-  @service rsyslog restart
+	@echo "Installing initscripts to /etc/init.d"
+	@install -m 0755 initscripts/PiGatewaySerial /etc/init.d
+	@install -m 0755 initscripts/PiGateway /etc/init.d
+	@echo "Installing syslog config to /etc/rsyslog.d"
+	@install -m 0755 initscripts/30-PiGatewaySerial.conf /etc/rsyslog.d
+	@install -m 0755 initscripts/30-PiGateway.conf  /etc/rsyslog.d
+	@service rsyslog restart
 
 enable-gw: install
-  @update-rc.d PiGateway defaults
+	@update-rc.d PiGateway defaults
 
 enable-gwserial: install
-  @update-rc.d PiGatewaySerial defaults
+	@update-rc.d PiGatewaySerial defaults
 
 remove-gw:
-  @update-rc.d -f PiGateway remove
+	@update-rc.d -f PiGateway remove
 
 remove-gwserial:
-  @update-rc.d -f PiGatewaySerial remove
+	@update-rc.d -f PiGatewaySerial remove
 
 uninstall: remove-gw remove-gwserial
-  @echo "Stopping daemon PiGatewaySerial (ignore errors)"
-  -@service PiGatewaySerial stop
-  @echo "Stopping daemon PiGateway (ignore errors)"
-  -@service PiGateway stop
-  @echo "removing files"
-  rm ${BINDIR}/PiGatewaySerial ${BINDIR}/PiGateway /etc/init.d/PiGatewaySerial /etc/init.d/PiGateway /etc/rsyslog.d/30-PiGatewaySerial.conf /etc/rsyslog.d/30-PiGateway.conf
+	@echo "Stopping daemon PiGatewaySerial (ignore errors)"
+	-@service PiGatewaySerial stop
+	@echo "Stopping daemon PiGateway (ignore errors)"
+	-@service PiGateway stop
+	@echo "removing files"
+	rm ${BINDIR}/PiGatewaySerial ${BINDIR}/PiGateway /etc/init.d/PiGatewaySerial /etc/init.d/PiGateway /etc/rsyslog.d/30-PiGatewaySerial.conf /etc/rsyslog.d/30-PiGateway.conf
+	

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ CCFLAGS=-Wall -Ofast -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -D_TTY_NAME=
 ifeq (${PIREV}, $(filter ${PIREV}, a02082))
 	# a02082 is PI 3 Model B (ARM Cortex A53)
 	CCFLAGS += -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8
-else ifeq (${PIREV}, $(filter ${PIREV}, a01041 a21041))
+else (${PIREV}, $(filter ${PIREV}, a01041 a21041))
 	# a01041 and a21041 are PI 2 Model B (Arm Cortex A7)
 	CCFLAGS += -march=armv7-a -mtune=cortex-a7 -mfpu=neon-vfpv4
 else

--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,14 @@ else (${PIREV}, $(filter ${PIREV}, a01041 a21041))
   # a01041 and a21041 are PI 2 Model B (Arm Cortex A7)
   CCFLAGS += -march=armv7-a -mtune=cortex-a7 -mfpu=neon-vfpv4
 else
-  # anything else is armv6
-  CCFLAGS += -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp
+	# anything else is armv6
+	CCFLAGS += -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp
 endif
 
 ifeq (${PIREV}, $(filter ${PIREV}, a01041 a21041 0010 a02082))
-  # a01041 and a21041 are PI 2 Model B with BPLUS Layout and 0010 is Pi Model B+ with BPLUS Layout
-  # a02082 is PI 3 Model B (ARM Cortex A53)
-  CCFLAGS += -D__PI_BPLUS
+	# a01041 and a21041 are PI 2 Model B with BPLUS Layout and 0010 is Pi Model B+ with BPLUS Layout
+	# a02082 is PI 3 Model B (ARM Cortex A53)
+	CCFLAGS += -D__PI_BPLUS
 endif
 
 # define all programs
@@ -58,52 +58,52 @@ CINCLUDE=-I. -I${RF24H}
 all: ${GATEWAY} ${GATEWAY_SERIAL}
 
 %.o: %.cpp %.h ${DEPS}
-  ${CC} -c -o $@ $< ${CCFLAGS} ${CINCLUDE}
+	${CC} -c -o $@ $< ${CCFLAGS} ${CINCLUDE}
 
 ${GATEWAY}: ${OBJS} ${GATEWAY_OBJS}
-  ${CC} -o $@ ${OBJS} ${GATEWAY_OBJS} ${CCFLAGS} ${CINCLUDE} -lrf24-bcm
+	${CC} -o $@ ${OBJS} ${GATEWAY_OBJS} ${CCFLAGS} ${CINCLUDE} -lrf24-bcm
 
 ${GATEWAY_SERIAL}: ${OBJS} ${GATEWAY_SERIAL_OBJS}
-  ${CC} -o $@ ${OBJS} ${GATEWAY_SERIAL_OBJS} ${CCFLAGS} ${CINCLUDE} -lrf24-bcm -lutil
+	${CC} -o $@ ${OBJS} ${GATEWAY_SERIAL_OBJS} ${CCFLAGS} ${CINCLUDE} -lrf24-bcm -lutil
 
 clean:
-  rm -rf $(PROGRAMS) $(GATEWAY) $(GATEWAY_SERIAL) ${OBJS} $(GATEWAY_OBJS) $(GATEWAY_SERIAL_OBJS)
+	rm -rf $(PROGRAMS) $(GATEWAY) $(GATEWAY_SERIAL) ${OBJS} $(GATEWAY_OBJS) $(GATEWAY_SERIAL_OBJS)
 
 install: all install-gatewayserial install-gateway install-initscripts
 
 install-gatewayserial:
-  @echo "Installing ${GATEWAY_SERIAL} to ${BINDIR}"
-  @install -m 0755 ${GATEWAY_SERIAL} ${BINDIR}
+	@echo "Installing ${GATEWAY_SERIAL} to ${BINDIR}"
+	@install -m 0755 ${GATEWAY_SERIAL} ${BINDIR}
 
 install-gateway:
-  @echo "Installing ${GATEWAY} to ${BINDIR}"
-  @install -m 0755 ${GATEWAY} ${BINDIR}
+	@echo "Installing ${GATEWAY} to ${BINDIR}"
+	@install -m 0755 ${GATEWAY} ${BINDIR}
 
 install-initscripts:
-  @echo "Installing initscripts to /etc/init.d"
-  @install -m 0755 initscripts/PiGatewaySerial /etc/init.d
-  @install -m 0755 initscripts/PiGateway /etc/init.d
-  @echo "Installing syslog config to /etc/rsyslog.d"
-  @install -m 0755 initscripts/30-PiGatewaySerial.conf /etc/rsyslog.d
-  @install -m 0755 initscripts/30-PiGateway.conf  /etc/rsyslog.d
-  @service rsyslog restart
+	@echo "Installing initscripts to /etc/init.d"
+	@install -m 0755 initscripts/PiGatewaySerial /etc/init.d
+	@install -m 0755 initscripts/PiGateway /etc/init.d
+	@echo "Installing syslog config to /etc/rsyslog.d"
+	@install -m 0755 initscripts/30-PiGatewaySerial.conf /etc/rsyslog.d
+	@install -m 0755 initscripts/30-PiGateway.conf  /etc/rsyslog.d
+	@service rsyslog restart
 
 enable-gw: install
-  @update-rc.d PiGateway defaults
+	@update-rc.d PiGateway defaults
 
 enable-gwserial: install
-  @update-rc.d PiGatewaySerial defaults
+	@update-rc.d PiGatewaySerial defaults
 
 remove-gw:
-  @update-rc.d -f PiGateway remove
+	@update-rc.d -f PiGateway remove
 
 remove-gwserial:
-  @update-rc.d -f PiGatewaySerial remove
+	@update-rc.d -f PiGatewaySerial remove
 
 uninstall: remove-gw remove-gwserial
-  @echo "Stopping daemon PiGatewaySerial (ignore errors)"
-  -@service PiGatewaySerial stop
-  @echo "Stopping daemon PiGateway (ignore errors)"
-  -@service PiGateway stop
-  @echo "removing files"
-  rm ${BINDIR}/PiGatewaySerial ${BINDIR}/PiGateway /etc/init.d/PiGatewaySerial /etc/init.d/PiGateway /etc/rsyslog.d/30-PiGatewaySerial.conf /etc/rsyslog.d/30-PiGateway.conf
+	@echo "Stopping daemon PiGatewaySerial (ignore errors)"
+	-@service PiGatewaySerial stop
+	@echo "Stopping daemon PiGateway (ignore errors)"
+	-@service PiGateway stop
+	@echo "removing files"
+	rm ${BINDIR}/PiGatewaySerial ${BINDIR}/PiGateway /etc/init.d/PiGatewaySerial /etc/init.d/PiGateway /etc/rsyslog.d/30-PiGatewaySerial.conf /etc/rsyslog.d/30-PiGateway.conf

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ CCFLAGS=-Wall -Ofast -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -D_TTY_NAME=
 ifeq (${PIREV}, $(filter ${PIREV}, a02082))
 	# a02082 is PI 3 Model B (ARM Cortex A53)
 	CCFLAGS += -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8
-else (${PIREV}, $(filter ${PIREV}, a01041 a21041))
+else ifeq (${PIREV}, $(filter ${PIREV}, a01041 a21041))
 	# a01041 and a21041 are PI 2 Model B (Arm Cortex A7)
 	CCFLAGS += -march=armv7-a -mtune=cortex-a7 -mfpu=neon-vfpv4
 else

--- a/MySensor.cpp
+++ b/MySensor.cpp
@@ -4,7 +4,7 @@
 
  Created by Henrik Ekblad <henrik.ekblad@gmail.com>
  12/10/14 - Ported to Raspberry Pi by OUJABER Mohamed <m.oujaber@gmail.com>
- 
+
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
  version 2 as published by the Free Software Foundation.
@@ -101,7 +101,7 @@ void MySensor::begin(void (*_msgCallback)(const MyMessage &), uint8_t _nodeId, b
 	debug(PSTR("%s started, id %d\n"), repeaterMode?"repeater":"sensor", nc.nodeId);
 
 	// If we got an id, set this node to use it
-	if (nc.nodeId != AUTO) { 
+	if (nc.nodeId != AUTO) {
 		setupNode();
 		// Wait configuration reply.
 		wait(2000);
@@ -130,7 +130,7 @@ void MySensor::setupRadio(rf24_pa_dbm_e paLevel, uint8_t channel, rf24_datarate_
 
 	// All nodes listen to broadcast pipe (for FIND_PARENT_RESPONSE messages)
 	RF24::openReadingPipe(BROADCAST_PIPE, TO_ADDR(BROADCAST_ADDRESS));
-	
+
 	RF24::printDetails();
 }
 
@@ -538,7 +538,13 @@ void MySensor::wait(unsigned long ms) {
 		// reset watchdog
 		wdt_reset();
 #endif
-		process();
+		try {
+			process();
+		} catch (const char* msg) {
+			printf("Unable to process radio messages. (Error: %s)\n", msg);
+			exit(EXIT_FAILURE);
+		}
+
 	}
 }
 
@@ -702,7 +708,7 @@ char* MySensor::ltoa(long value, char* result, int base) {
 char * MySensor::dtostrf(float f, int width, int decimals, char *result)
 {
     char widths[3];
-    char decimalss[3];  
+    char decimalss[3];
     char format[100];
     itoa(width,widths,10);
     itoa(decimals,decimalss,10);
@@ -711,7 +717,7 @@ char * MySensor::dtostrf(float f, int width, int decimals, char *result)
     strcat(format,".");
     strcat(format,decimalss);
     strcat(format,"f");
-  
+
     sprintf(result,format,f);
     return result;
 }


### PR DESCRIPTION
Added try-catch blocks to catch thrown exceptions gracefully. Previously the gateway terminated (with the RF24 **not** connected) with the following message: `terminate called after throwing an instance of 'char const*'`

Tested successfully on RPi2 and RPi3.