### PR TITLE
Updated Makefile for RPi 3 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,20 +15,24 @@ TTY_GROUPNAME := tty
 CC=g++
 # get PI Revision from cpuinfo
 PIREV := $(shell cat /proc/cpuinfo | grep Revision | cut -f 2 -d ":" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$$//')
-CCFLAGS=-Wall -Ofast -mfpu=vfp -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -mtune=arm1176jzf-s -D_TTY_NAME=\"${TTY_NAME}\" -D_TTY_GROUPNAME=\"${TTY_GROUPNAME}\"
+CCFLAGS=-Wall -Ofast -lpthread -g -D__Raspberry_Pi -mfloat-abi=hard -D_TTY_NAME=\"${TTY_NAME}\" -D_TTY_GROUPNAME=\"${TTY_GROUPNAME}\"
 
-ifeq (${PIREV},$(filter ${PIREV},a01041 a21041))
-	# a01041 and a21041 are PI 2 Model B and armv7
-	CCFLAGS += -march=armv7-a 
+ifeq (${PIREV}, $(filter ${PIREV}, a02082))
+  # a02082 is PI 3 Model B (ARM Cortex A53)
+  CCFLAGS += -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8
+else ifeq (${PIREV}, $(filter ${PIREV}, a01041 a21041))
+  # a01041 and a21041 are PI 2 Model B (Arm Cortex A7)
+  CCFLAGS += -march=armv7-a -mtune=cortex-a7 -mfpu=neon-vfpv4
 else
 	# anything else is armv6
-	CCFLAGS += -march=armv6zk
+	CCFLAGS += -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp
 endif
 
-ifeq (${PIREV},$(filter ${PIREV},a01041 a21041 0010))
+ifeq (${PIREV}, $(filter ${PIREV}, a01041 a21041 0010 a02082))
 	# a01041 and a21041 are PI 2 Model B with BPLUS Layout and 0010 is Pi Model B+ with BPLUS Layout
+	# a02082 is PI 3 Model B (ARM Cortex A53)
 	CCFLAGS += -D__PI_BPLUS
-endif 
+endif
 
 # define all programs
 PROGRAMS = MyGateway MySensor MyMessage PiEEPROM
@@ -67,14 +71,14 @@ clean:
 
 install: all install-gatewayserial install-gateway install-initscripts
 
-install-gatewayserial: 
+install-gatewayserial:
 	@echo "Installing ${GATEWAY_SERIAL} to ${BINDIR}"
 	@install -m 0755 ${GATEWAY_SERIAL} ${BINDIR}
 
-install-gateway: 
+install-gateway:
 	@echo "Installing ${GATEWAY} to ${BINDIR}"
 	@install -m 0755 ${GATEWAY} ${BINDIR}
-	
+
 install-initscripts:
 	@echo "Installing initscripts to /etc/init.d"
 	@install -m 0755 initscripts/PiGatewaySerial /etc/init.d
@@ -86,16 +90,16 @@ install-initscripts:
 
 enable-gw: install
 	@update-rc.d PiGateway defaults
-	
+
 enable-gwserial: install
 	@update-rc.d PiGatewaySerial defaults
-	
+
 remove-gw:
 	@update-rc.d -f PiGateway remove
-	
+
 remove-gwserial:
 	@update-rc.d -f PiGatewaySerial remove
-	
+
 uninstall: remove-gw remove-gwserial
 	@echo "Stopping daemon PiGatewaySerial (ignore errors)"
 	-@service PiGatewaySerial stop
@@ -103,4 +107,3 @@ uninstall: remove-gw remove-gwserial
 	-@service PiGateway stop
 	@echo "removing files"
 	rm ${BINDIR}/PiGatewaySerial ${BINDIR}/PiGateway /etc/init.d/PiGatewaySerial /etc/init.d/PiGateway /etc/rsyslog.d/30-PiGatewaySerial.conf /etc/rsyslog.d/30-PiGateway.conf
-	


### PR DESCRIPTION
Updated Makefile for RPi 3 support (Cortex A53). Adjustments for RPi2 and RPi1 compiler flags.

RPi 1: ARM 1176JZF-S
RPi 2: ARM Cortex-A7
RPi 3: ARM Cortex-A53

Sources:
- https://www.raspberrypi.org/forums/viewtopic.php?t=144115&p=951819
- https://en.wikipedia.org/wiki/ARM_Cortex-A7
- https://en.wikipedia.org/wiki/ARM_Cortex-A53
- https://en.wikipedia.org/wiki/ARM11